### PR TITLE
fix: requests to /robots.txt return 404

### DIFF
--- a/web/src/handler.rs
+++ b/web/src/handler.rs
@@ -278,8 +278,13 @@ pub async fn single_block_with_conflicting_transactions(
 
 //##### OTHER PAGES
 
-pub async fn robots_txt() -> Result<actix_files::NamedFile> {
-    Ok(actix_files::NamedFile::open("www/robots.txt")?)
+pub async fn robots_txt() -> Result<HttpResponse, Error> {
+    let robots_txt = "User-agent: *
+Allow: /
+Disallow: /debug/*";
+    Ok(HttpResponse::Ok()
+        .content_type("text/plain")
+        .body(robots_txt))
 }
 
 include!(concat!(env!("OUT_DIR"), "/list_sanctioned_addr.rs"));

--- a/www/robots.txt
+++ b/www/robots.txt
@@ -1,3 +1,0 @@
-User-agent: *
-Allow: /
-Disallow: /debug/*


### PR DESCRIPTION
The old robots_txt() handler function did not take custom www-dirs
into account. As the robots.txt file is not expected to change, it
can be served via static string.

closes #3 