### PR TITLE
fix: GitHub Actions Rust CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,10 +1,11 @@
 name: Rust
 
 on:
+  workflow_dispatch:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
The CI was only configured for the `main` branch (while this repo has only a `master` branch) and manual execution was not enabled.