### PR TITLE
fix: missing transaction template num tx

### DIFF
--- a/www/templates/subpage/template_and_block.html
+++ b/www/templates/subpage/template_and_block.html
@@ -107,8 +107,8 @@
                             </summary>
                     {% endif %}
 
-                    {{ transaction::block_transaction(tx=tx, place="template", tx_count=block_with_tx.block.block_tx) }}
-            
+                    {{ transaction::block_transaction(tx=tx, place="template", tx_count=block_with_tx.block.template_tx) }}
+
                     {% if loop.last and loop.index >= 16 %}
                         </details>
                     {% endif %}


### PR DESCRIPTION
Previously, the block transaction count was used for the to show the position in the template.

closes #10 