### PR TITLE
add: enable docker config via ENV vars

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,10 @@
 target
+daemon/target
+shared/target
+web/target
 docs
 artwork
 README.md
 LICENSE
-contrib
+contrib/docker/Dockerfile.*
+contrib/docker/README.md

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -1,0 +1,69 @@
+name: docker-images
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+
+defaults:
+  run:
+    working-directory: ./
+
+jobs:
+  build-and-push-daemon-container-image:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: checkout repo
+        uses: actions/checkout@v2
+      -
+        name: Build miningpool-observer-daemon and push
+        id: docker_build_daemon
+        uses: docker/build-push-action@v2
+        with:
+          file: contrib/docker/Dockerfile.daemon
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: b10c/miningpool-observer:daemon-latest
+  build-and-push-web-container-image:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: checkout repo
+        uses: actions/checkout@v2
+      -
+        name: Build miningpool-observer-web and push
+        id: docker_build_web
+        uses: docker/build-push-action@v2
+        with:
+          file: contrib/docker/Dockerfile.web
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: b10c/miningpool-observer:web-latest

--- a/contrib/docker/Dockerfile.daemon
+++ b/contrib/docker/Dockerfile.daemon
@@ -1,12 +1,18 @@
-FROM rust as builder
+FROM rust:1-slim-buster as builder
 WORKDIR app
 COPY . .
-RUN cargo build --release --bin miningpool-observer-daemon
-
-FROM debian:stable-slim as runtime
 RUN apt-get -y update
 RUN apt-get -y install libpq-dev
+RUN cargo build --release --bin miningpool-observer-daemon
+
+FROM debian:buster-slim as runtime
+RUN apt-get -y update
+RUN apt-get -y install libpq-dev
+
+COPY contrib/docker/entrypoint-daemon.sh /
 WORKDIR /app
 COPY --from=builder /app/target/release/miningpool-observer-daemon /app/daemon
+
 ENV CONFIG_FILE=/app/daemon-config.toml
-ENTRYPOINT ["/app/daemon"]
+ENTRYPOINT ["/entrypoint-daemon.sh"]
+CMD ["/app/daemon"]

--- a/contrib/docker/Dockerfile.web
+++ b/contrib/docker/Dockerfile.web
@@ -1,13 +1,19 @@
-FROM rust as builder
+FROM rust:1-slim-buster as builder
 WORKDIR app
 COPY . .
-RUN cargo build --release --bin miningpool-observer-web
-
-FROM debian:stable-slim as runtime
 RUN apt-get -y update
 RUN apt-get -y install libpq-dev
+RUN cargo build --release --bin miningpool-observer-web
+
+FROM debian:buster-slim as runtime
+RUN apt-get -y update
+RUN apt-get -y install libpq-dev
+
+COPY contrib/docker/entrypoint-web.sh /
 WORKDIR /app
 COPY --from=builder /app/target/release/miningpool-observer-web /app/web
 COPY --from=builder /app/www /app/www
+
 ENV CONFIG_FILE=/app/web-config.toml
-ENTRYPOINT ["/app/web"]
+ENTRYPOINT ["/entrypoint-web.sh"]
+CMD ["/app/web"]

--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -12,7 +12,6 @@ docker build . -f contrib/Dockerfile.web
 
 When using `docker run`, bind mount the configuration files with
 
-
 ```
 --mount type=bind,source="$(pwd)"/daemon-config.toml,target=/app/daemon-config.toml
 ```
@@ -22,3 +21,9 @@ and
 ```
 --mount type=bind,source="$(pwd)"/web-config.toml,target=/app/web-config.toml
 ```
+
+Alternativly, enviroment variables can be used to generate the configuration
+file in the entrypoint-{daemon,web}.sh files. Set the
+`CREATE_CONFIG_FROM_ENVVARS` variable to make the entrypoints generate a
+configuration. Consult the entrypoint-{daemon,web}.sh scripts for the
+respective enviroment variables to set.

--- a/contrib/docker/entrypoint-daemon.sh
+++ b/contrib/docker/entrypoint-daemon.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+if [ -n "$CREATE_CONFIG_FROM_ENVVARS" ]; then
+  cat > $CONFIG_FILE <<DELIM
+
+# miningpool.observer deamon configuration file created in entrypoint-daemon.sh
+# to disable the creation of this configuration file unset CREATE_CONFIG_FROM_ENVVARS
+
+database_url = "$DATABASE_URL"
+log_level = "$LOG_LEVEL"
+rpc_host = "$RPC_HOST"
+rpc_port = $RPC_PORT
+rpc_user = "$RPC_USER"
+rpc_password = "$RPC_PASSWORD"
+
+[prometheus]
+    enable = $PROMETHEUS_ENABLE
+    address = "$PROMETHEUS_ADDRESS"
+DELIM
+fi
+
+exec "$@"

--- a/contrib/docker/entrypoint-web.sh
+++ b/contrib/docker/entrypoint-web.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+if [ -n "$CREATE_CONFIG_FROM_ENVVARS" ]; then
+  cat > $CONFIG_FILE <<DELIM
+
+# miningpool.observer web configuration file created in entrypoint-web.sh
+# to disable the creation of this configuration file unset CREATE_CONFIG_FROM_ENVVARS
+
+database_url = "$DATABASE_URL"
+address = "$ADDRESS"
+log_level = "$LOG_LEVEL"
+www_dir_path = "/app/www"
+
+[site]
+    base_url = "$BASE_URL"
+    title = "$SITE_TITLE"
+    footer = """
+      $SITE_FOOTER
+    """
+DELIM
+fi
+
+exec "$@"


### PR DESCRIPTION
This allows to configure both docker containers via ENV variables.
The TOML configuration is generated in the entrypoint-{web,daemon}.sh
files.