### PR TITLE
add: 'Taproot'-tag to P2TR spending transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,7 +1952,7 @@ dependencies = [
 [[package]]
 name = "rawtx-rs"
 version = "0.1.0"
-source = "git+https://github.com/0xB10C/rawtx-rs?branch=master#e3e255dc8f65cda54f099ff9c208c06b5b3e8d34"
+source = "git+https://github.com/0xB10C/rawtx-rs?branch=master#33d65a4bc751a24faabd5978ce3e1a6866fd871f"
 dependencies = [
  "bitcoin",
  "hex",

--- a/daemon/src/processing.rs
+++ b/daemon/src/processing.rs
@@ -214,6 +214,10 @@ fn get_transaction_tags(
         tags.push(tags::TxTag::SegWit as i32);
     }
 
+    if raw_tx_info.is_spending_taproot() {
+        tags.push(tags::TxTag::Taproot as i32);
+    }
+
     if raw_tx_info.is_spending_multisig() {
         tags.push(tags::TxTag::Multisig as i32);
     }

--- a/shared/src/tags.rs
+++ b/shared/src/tags.rs
@@ -53,6 +53,7 @@ pub enum TxTag {
     Coinbase = 4099,
     Coinjoin = 4100,
     SegWit = 4110,
+    Taproot = 4111,
     Multisig = 4120,
     RbfSignaling = 4130,
     OpReturn = 4140,
@@ -74,6 +75,7 @@ impl TryFrom<i32> for TxTag {
             x if x == TxTag::ZeroFee as i32 => Ok(TxTag::ZeroFee),
             x if x == TxTag::HighFeerate as i32 => Ok(TxTag::HighFeerate),
             x if x == TxTag::SegWit as i32 => Ok(TxTag::SegWit),
+            x if x == TxTag::Taproot as i32 => Ok(TxTag::Taproot),
             x if x == TxTag::Multisig as i32 => Ok(TxTag::Multisig),
             x if x == TxTag::RbfSignaling as i32 => Ok(TxTag::RbfSignaling),
             x if x == TxTag::OpReturn as i32 => Ok(TxTag::OpReturn),
@@ -92,7 +94,7 @@ impl TryFrom<i32> for TxTag {
 }
 
 impl TxTag {
-    pub const TX_TAGS: &'static [TxTag; 18] = &[
+    pub const TX_TAGS: &'static [TxTag; 19] = &[
         // important / danger
         TxTag::FromSanctioned,
         TxTag::ToSanctioned,
@@ -107,6 +109,7 @@ impl TxTag {
         // secondary
         TxTag::Coinbase,
         TxTag::SegWit,
+        TxTag::Taproot,
         TxTag::Multisig,
         TxTag::RbfSignaling,
         TxTag::OpReturn,
@@ -123,6 +126,14 @@ impl TxTag {
                 Tag {
                     name: "SegWit spending".to_string(),
                     description: vec!["The transaction has at least one SegWit input.".to_string()],
+                    color: GRAY,
+                    text_color: WHITE,
+                }
+            },
+            TxTag::Taproot => {
+                Tag {
+                    name: "Taproot spending".to_string(),
+                    description: vec!["The transaction has at least one Taproot input.".to_string()],
                     color: GRAY,
                     text_color: WHITE,
                 }


### PR DESCRIPTION
Shows a "Taproot" tag on e.g. https://miningpool.observer/missing/b8b4144d80ee5c6c10c450d4057c62745eeb37b3306e6bfbf480d4992689dc54 (a P2TR spend that currently aren't being included by F2Pool and AntPool). 

![image](https://user-images.githubusercontent.com/19157360/141831283-4392d5bf-6b2e-494d-bd67-fcf7c1dcc519.png)
