### PR TITLE
add: functionallity to re-tag transactions

### DIFF
--- a/daemon-config.toml.example
+++ b/daemon-config.toml.example
@@ -25,6 +25,10 @@ rpc_port = 8332
 # rpc_user = ""
 # rpc_password = ""
 
+# Re-process all database transactions and apply new tags on deamon-startup.
+# This might be requried after an update. You don't need to run this everytime.
+# Requires Bitcoin Core with txindex and no prune.
+retag_transactions = false
 
 # Prometheus Metric Server
 # Don't expose this publicly.

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -178,6 +178,11 @@ pub fn insert_debug_template_selection_infos(
     Ok(())
 }
 
+pub fn all_transactions(conn: &PgConnection) -> Result<Vec<Transaction>, diesel::result::Error> {
+    use schema::transaction::dsl::*;
+    transaction.load::<Transaction>(conn)
+}
+
 pub fn unknown_pool_blocks(conn: &PgConnection) -> Result<Vec<Block>, diesel::result::Error> {
     use schema::block::dsl::*;
     block
@@ -195,6 +200,19 @@ pub fn update_pool_name_with_block_id(
 
     diesel::update(block.filter(id.eq(block_id)))
         .set(pool_name.eq(new_pool_name))
+        .execute(conn)?;
+    Ok(())
+}
+
+pub fn update_transaction_tags(
+    new_tags: &Vec<i32>,
+    tx_id: &Vec<u8>,
+    conn: &PgConnection,
+) -> Result<(), diesel::result::Error> {
+    use schema::transaction::dsl::*;
+    diesel::update(transaction)
+        .filter(txid.eq(tx_id))
+        .set(tags.eq(new_tags))
         .execute(conn)?;
     Ok(())
 }

--- a/daemon/src/processing.rs
+++ b/daemon/src/processing.rs
@@ -160,6 +160,19 @@ fn is_tx_opreturn(tx: &Transaction) -> bool {
     false
 }
 
+pub fn retag_transaction(tx: &bitcoin::Transaction, tx_info: &TxInfo) -> Vec<i32> {
+    if let Ok(raw_tx_info) = RawTxInfo::new(&tx) {
+        let new_tags = get_transaction_tags(
+            tx_info,
+            &raw_tx_info,
+            false,
+            &HashMap::new(),
+        );
+        return new_tags;
+    }
+    return vec![];
+}
+
 fn get_transaction_tags(
     tx_info: &TxInfo,
     raw_tx_info: &RawTxInfo,

--- a/shared/src/config.rs
+++ b/shared/src/config.rs
@@ -19,6 +19,7 @@ struct DaemonTomlConfig {
     rpc_password: Option<String>,
     database_url: String,
     log_level: String,
+    retag_transactions: bool,
     prometheus: PrometheusConfig,
 }
 
@@ -33,6 +34,7 @@ pub struct DaemonConfig {
     pub rpc_auth: Auth,
     pub database_url: String,
     pub log_level: LevelFilter,
+    pub retag_transactions: bool,
     pub prometheus: PrometheusConfig,
 }
 
@@ -65,6 +67,7 @@ pub fn load_daemon_config() -> Result<DaemonConfig, ConfigError> {
         rpc_auth,
         database_url: config.database_url,
         log_level,
+        retag_transactions: config.retag_transactions,
         prometheus: config.prometheus,
     });
 }


### PR DESCRIPTION
When adding new tags, the tags for the transactions in the database can now be updated. This can be controlled via the configuration parameter `retag_transactions` (true/false).

Closes https://github.com/0xB10C/miningpool-observer/issues/31