### PR TITLE
Bump minimum Bitcoin Core to v22

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This project is inspired by [BitMex Research: Bitcoin Miner Transaction Fee Gath
 
 The miningpool-observer project is built with self-hosting in mind.
 Both private and public instances, like e.g. [miningpool.observer](https://miningpool.observer), are supported.
-Requirements are a Bitcoin Core node v22.0 (currently, you'll need a self-compiled `master` build! requires [PR #18772 (rpc: calculate fees in getblock using BlockUndo data)](https://github.com/bitcoin/bitcoin/pull/18772))) and a PostgreSQL database.
+Requirements are a Bitcoin Core node v22.0 and a PostgreSQL database.
 
 See [docs/self-hosting.md](docs/self-hosting.md) for more information.
 ## Development

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -26,7 +26,7 @@ A NixOS package and module is available as well (contact @0xB10C for more inform
 
 ### Requirements
 
-- Bitcoin Core v22.0 or newer (the `master` branch works too, needs the commits from [PR #18772 (rpc: calculate fees in getblock using BlockUndo data)](https://github.com/bitcoin/bitcoin/pull/18772))
+- Bitcoin Core v22.0 or newer
 - A PostgreSQL database version 10 or newer (and disk space for around 150 MB of data per month)
 
 ### Database


### PR DESCRIPTION
This avoids the need to apply a patch and self compile.

https://github.com/bitcoin/bitcoin/pull/18772 was merged and made it into ~v23.0~ v22.0

(haven't tested this yet)