### PR TITLE
cleanup: resolve build warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --verbose --all-features
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose --all-features

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -26,6 +26,10 @@ chrono = { version = "0.4" }
 prometheus = "0.12.0"
 lazy_static = "1.4.0"
 
+[features]
+# Treat warnings as a build error.
+strict = []
+
 [build-dependencies]
 serde = "1"
 serde_json = "1"

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "strict", deny(warnings))]
+
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::thread;
 use std::time;

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::convert::TryFrom;
 use std::thread;
 use std::time;
 use std::time::Instant;

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -901,14 +901,27 @@ fn retag_transactions(rpc_client: Client, db_pool: db_pool::PgPool) {
 
                 // we can compare them here, as they are both sorted
                 if new_tags != old_tags {
-                    db::update_transaction_tags(&new_tags, &tx_in_db.txid.clone(), &conn);
-                    log::info!(
-                        target: LOG_TARGET_RETAG_TX,
-                        "Retagged transaction {}: old={:?} new={:?}",
-                        hex::encode(tx_in_db.txid.clone()),
-                        old_tags,
-                        new_tags,
-                    );
+                    match db::update_transaction_tags(&new_tags, &tx_in_db.txid.clone(), &conn) {
+                        Ok(()) => { 
+                            log::info!(
+                                target: LOG_TARGET_RETAG_TX,
+                                "Retagged transaction {}: old={:?} new={:?}",
+                                hex::encode(tx_in_db.txid.clone()),
+                                old_tags,
+                                new_tags,
+                            );
+                        },
+                        Err(e) => {
+                            log::info!(
+                                target: LOG_TARGET_RETAG_TX,
+                                "Could not retagged transaction {}: old={:?} new={:?}, error={}",
+                                hex::encode(tx_in_db.txid.clone()),
+                                old_tags,
+                                new_tags,
+                                e,
+                            );
+                        },
+                    };
                 };
                 counter += 1;
                 if counter % 100 == 0 {

--- a/daemon/src/processing.rs
+++ b/daemon/src/processing.rs
@@ -17,7 +17,7 @@ use rawtx_rs::tx::{is_opreturn_counterparty, is_p2ms_counterparty, is_p2sh_count
 use rawtx_rs::{input::InputType, output::OutputType};
 
 use bitcoin::hash_types::Txid;
-use bitcoin::{network::constants::Network, Address, Amount, Transaction, Sequence, PackedLockTime, Witness};
+use bitcoin::{network::constants::Network, Address, Amount, Transaction};
 
 pub const LOG_TARGET_PROCESSING: &str = "processing";
 
@@ -1062,7 +1062,7 @@ pub fn log_processing_error(msg: &str) {
 mod tests {
     use super::*;
     use crate::model::TxInfo;
-    use bitcoin::{consensus, Amount, OutPoint, Script, Transaction, TxIn, TxOut};
+    use bitcoin::{consensus, Amount, OutPoint, Script, Transaction, TxIn, TxOut, Sequence, PackedLockTime, Witness};
     use hex;
 
     #[test]

--- a/shared/src/model.rs
+++ b/shared/src/model.rs
@@ -13,8 +13,8 @@ use std::hash::{Hash, Hasher};
 // Database models shared between web and daemon.
 
 /// This is used to query a block from the database. Use [NewBlock] for inserting.
-#[primary_key(hash)]
 #[derive(Queryable, Serialize, Identifiable)]
+#[primary_key(hash)]
 #[table_name = "block"]
 pub struct Block {
     pub id: i32,

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -29,6 +29,11 @@ resvg = "0.14.1"
 usvg = "0.14.1"
 tiny-skia = "0.5.1"
 
+
+[features]
+# Treat warnings as a build error.
+strict = []
+
 [build-dependencies]
 serde = "1"
 serde_json = "1"

--- a/web/src/db.rs
+++ b/web/src/db.rs
@@ -458,8 +458,6 @@ const QUERY_COUNT_MISSING_TRANSACTIONS: &str = r#"
 
 #[derive(QueryableByName)]
 struct MissingTransactionCountInfo {
-    #[sql_type = "BigInt"]
-    cnt: i64,
     #[sql_type = "Bytea"]
     txid: Vec<u8>,
 }

--- a/web/src/db.rs
+++ b/web/src/db.rs
@@ -456,7 +456,7 @@ const QUERY_COUNT_MISSING_TRANSACTIONS: &str = r#"
         ) AS tx_missing_from_multiple_blocks;
     ;"#;
 
-#[derive(Debug, QueryableByName)]
+#[derive(QueryableByName)]
 struct MissingTransactionCountInfo {
     #[sql_type = "BigInt"]
     cnt: i64,

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "strict", deny(warnings))]
+
 #[macro_use]
 extern crate diesel;
 


### PR DESCRIPTION
Next to cleaning up a bit, we now fail the CI if there are warnings.

Closes https://github.com/0xB10C/miningpool-observer/issues/39