### PR TITLE
change: drop "./" from www_dir_path in example

### DIFF
--- a/web-config.toml.example
+++ b/web-config.toml.example
@@ -14,7 +14,7 @@ log_level = "info"
 # This directory contains the HTML templates and static resources
 # When using the docker image, the image already contains these under "/app/www".
 # Use "/app/www" when using docker.
-www_dir_path = "./www"
+www_dir_path = "www"
 
 [site]
 


### PR DESCRIPTION
This allows using a relative path for the "www" directory. 

Discussed in https://github.com/0xB10C/miningpool-observer/pull/40#discussion_r971808209