### PR TITLE
systemd: restart when bitcoind restarts

### DIFF
--- a/contrib/miningpool-observer-daemon.service
+++ b/contrib/miningpool-observer-daemon.service
@@ -1,12 +1,13 @@
 [Unit]
 Description=Miningpool Observer Daemon
 After=bitcoind.service
+PartOf=bitcoind.service
 
 [Service]
 User=miningobs
 Group=miningobs
 WorkingDirectory=/home/miningobs/miningpool-observer
-ExecStart=/home/miningobs/miningpool-observer/target/release/miningpool-observer-daemon 
+ExecStart=/home/miningobs/miningpool-observer/target/release/miningpool-observer-daemon
 Type=simple
 KillMode=process
 TimeoutSec=60


### PR DESCRIPTION
This prevents "ThreadRPCServer incorrect password attempt from 127.0.0.1:..." errors.

I'm using cookie based authentication, and the cookie changes every time bitcoind is restarted.

There might be a more elegant way to fix this, but this works. I haven't had this problem with c-lightning, electrs and nbexplorer, so their implementation might provide some hints.