### PR TITLE
fix: regenerate schema.rs after upgrading to diesel 2.0

### DIFF
--- a/diesel.toml
+++ b/diesel.toml
@@ -1,2 +1,3 @@
 [print_schema]
 file = "shared/src/schema.rs"
+patch_file = "shared/src/schema.patch"

--- a/shared/src/schema.patch
+++ b/shared/src/schema.patch
@@ -1,0 +1,103 @@
+This is a patch for the generated shared/src/schema.rs file. It's applied
+automatically by Diesel after generating the shared/src/schema.rs file.
+It removes the Nullable wrapping introduced in Diesel 2.0 as it is not needed here.
+See https://diesel.rs/guides/migration_guide.html#changed-nullability-of-array-elements
+
+diff --git a/shared/src/schema.rs b/shared/src/schema.rs
+index 8b77f0a..8d5a1a1 100644
+--- a/shared/src/schema.rs
++++ b/shared/src/schema.rs
+@@ -3,48 +3,48 @@
+ diesel::table! {
+     block (hash) {
+         id -> Int4,
+         hash -> Bytea,
+         prev_hash -> Bytea,
+         height -> Int4,
+-        tags -> Array<Nullable<Int4>>,
++        tags -> Array<Int4>,
+         missing_tx -> Int4,
+         extra_tx -> Int4,
+         shared_tx -> Int4,
+         sanctioned_missing_tx -> Int4,
+         equality -> Float4,
+         block_time -> Timestamp,
+         block_seen_time -> Timestamp,
+         block_tx -> Int4,
+         block_sanctioned -> Int4,
+         block_cb_value -> Int8,
+         block_cb_fees -> Int8,
+         block_weight -> Int4,
+-        block_pkg_weights -> Array<Nullable<Int8>>,
+-        block_pkg_feerates -> Array<Nullable<Float4>>,
++        block_pkg_weights -> Array<Int8>,
++        block_pkg_feerates -> Array<Float4>,
+         pool_name -> Text,
+         pool_link -> Text,
+         pool_id_method -> Text,
+         template_tx -> Int4,
+         template_time -> Timestamp,
+         template_sanctioned -> Int4,
+         template_cb_value -> Int8,
+         template_cb_fees -> Int8,
+         template_weight -> Int4,
+-        template_pkg_weights -> Array<Nullable<Int8>>,
+-        template_pkg_feerates -> Array<Nullable<Float4>>,
++        template_pkg_weights -> Array<Int8>,
++        template_pkg_feerates -> Array<Float4>,
+     }
+ }
+ 
+ diesel::table! {
+     conflicting_transactions (block_id, template_txids, block_txids) {
+         block_id -> Int4,
+-        template_txids -> Array<Nullable<Bytea>>,
+-        block_txids -> Array<Nullable<Bytea>>,
+-        conflicting_outpoints_txids -> Array<Nullable<Bytea>>,
+-        conflicting_outpoints_vouts -> Array<Nullable<Int4>>,
++        template_txids -> Array<Bytea>,
++        block_txids -> Array<Bytea>,
++        conflicting_outpoints_txids -> Array<Bytea>,
++        conflicting_outpoints_vouts -> Array<Int4>,
+     }
+ }
+ 
+ diesel::table! {
+     debug_template_selection (block_id, template_time) {
+         block_id -> Int4,
+@@ -66,13 +66,13 @@ diesel::table! {
+ diesel::table! {
+     sanctioned_transaction_info (block_id, transaction_txid) {
+         block_id -> Int4,
+         transaction_txid -> Bytea,
+         in_block -> Bool,
+         in_template -> Bool,
+-        addresses -> Array<Nullable<Text>>,
++        addresses -> Array<Text>,
+     }
+ }
+ 
+ diesel::table! {
+     sanctioned_utxo (txid, vout) {
+         txid -> Bytea,
+@@ -97,17 +97,17 @@ diesel::table! {
+     transaction (txid) {
+         txid -> Bytea,
+         sanctioned -> Bool,
+         vsize -> Int4,
+         fee -> Int8,
+         output_sum -> Int8,
+-        tags -> Array<Nullable<Int4>>,
++        tags -> Array<Int4>,
+         input_count -> Int4,
+-        inputs -> Array<Nullable<Text>>,
++        inputs -> Array<Text>,
+         output_count -> Int4,
+-        outputs -> Array<Nullable<Text>>,
++        outputs -> Array<Text>,
+     }
+ }
+ 
+ diesel::table! {
+     transaction_only_in_block (block_id, transaction_txid) {
+         block_id -> Int4,

--- a/shared/src/schema.rs
+++ b/shared/src/schema.rs
@@ -1,6 +1,6 @@
-use diesel::prelude::*;
+// @generated automatically by Diesel CLI.
 
-table! {
+diesel::table! {
     block (hash) {
         id -> Int4,
         hash -> Bytea,
@@ -35,7 +35,7 @@ table! {
     }
 }
 
-table! {
+diesel::table! {
     conflicting_transactions (block_id, template_txids, block_txids) {
         block_id -> Int4,
         template_txids -> Array<Bytea>,
@@ -45,7 +45,7 @@ table! {
     }
 }
 
-table! {
+diesel::table! {
     debug_template_selection (block_id, template_time) {
         block_id -> Int4,
         template_time -> Timestamp,
@@ -56,14 +56,14 @@ table! {
     }
 }
 
-table! {
+diesel::table! {
     node_info (id) {
         id -> Int4,
         version -> Text,
     }
 }
 
-table! {
+diesel::table! {
     sanctioned_transaction_info (block_id, transaction_txid) {
         block_id -> Int4,
         transaction_txid -> Bytea,
@@ -73,7 +73,7 @@ table! {
     }
 }
 
-table! {
+diesel::table! {
     sanctioned_utxo (txid, vout) {
         txid -> Bytea,
         vout -> Int4,
@@ -83,7 +83,7 @@ table! {
     }
 }
 
-table! {
+diesel::table! {
     sanctioned_utxo_scan_info (end_time) {
         end_time -> Timestamp,
         end_height -> Int4,
@@ -93,7 +93,7 @@ table! {
     }
 }
 
-table! {
+diesel::table! {
     transaction (txid) {
         txid -> Bytea,
         sanctioned -> Bool,
@@ -108,7 +108,7 @@ table! {
     }
 }
 
-table! {
+diesel::table! {
     transaction_only_in_block (block_id, transaction_txid) {
         block_id -> Int4,
         position -> Int4,
@@ -116,7 +116,7 @@ table! {
     }
 }
 
-table! {
+diesel::table! {
     transaction_only_in_template (block_id, transaction_txid) {
         block_id -> Int4,
         position -> Int4,
@@ -125,11 +125,11 @@ table! {
     }
 }
 
-joinable!(sanctioned_transaction_info -> transaction (transaction_txid));
-joinable!(transaction_only_in_block -> transaction (transaction_txid));
-joinable!(transaction_only_in_template -> transaction (transaction_txid));
+diesel::joinable!(sanctioned_transaction_info -> transaction (transaction_txid));
+diesel::joinable!(transaction_only_in_block -> transaction (transaction_txid));
+diesel::joinable!(transaction_only_in_template -> transaction (transaction_txid));
 
-allow_tables_to_appear_in_same_query!(
+diesel::allow_tables_to_appear_in_same_query!(
     block,
     conflicting_transactions,
     debug_template_selection,


### PR DESCRIPTION
During the upgrade to diesel 2.0 in the previous commits, the schema.rs file wasn't regenerated. Diesel 2.0 now supports PostgreSQL arrays containing NULL values. See https://diesel.rs/guides/migration_guide.html#changed-nullability-of-array-elements

We don't use NULL values in arrays and remove the Nullable wrapper in a patch as described in the 1.4 to 2.0 migration guide. The patch might need to be updated if more tables using PostgreSQL arrays are added.