### PR TITLE
log, show, and provide a metric for template sigops

### DIFF
--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -756,6 +756,11 @@ fn select_best_template_for_block(
 }
 
 fn log_template_infos(t: &GetBlockTemplateResult) {
+    let template_sigops = t
+        .transactions
+        .iter()
+        .map(|tx| tx.sigops as u64)
+        .sum::<u64>();
     log::info!(
         target: LOG_TARGET_STATS,
         "New Template based on {} | height {} | {} tx | coinbase {} | sigops {}",
@@ -763,11 +768,12 @@ fn log_template_infos(t: &GetBlockTemplateResult) {
         t.height,
         t.transactions.len(),
         t.coinbase_value,
-        t.transactions.iter().map(|tx| tx.sigops as u64).sum::<u64>(),
+        template_sigops,
     );
 
     metrics::STAT_CURRENT_TEMPLATE_TRANSACTIONS_GAUGE.set(t.transactions.len() as i64);
     metrics::STAT_CURRENT_TEMPLATE_COINBASE_VALUE_GAUGE.set(t.coinbase_value.to_sat() as i64);
+    metrics::STAT_CURRENT_TEMPLATE_SIGOPS_GAUGE.set(template_sigops as i64);
 }
 
 fn scantxoutset_sanctioned_tx(

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -758,11 +758,12 @@ fn select_best_template_for_block(
 fn log_template_infos(t: &GetBlockTemplateResult) {
     log::info!(
         target: LOG_TARGET_STATS,
-        "New Template based on {} | height {} | {} tx | coinbase {}",
+        "New Template based on {} | height {} | {} tx | coinbase {} | sigops {}",
         t.previous_block_hash,
         t.height,
         t.transactions.len(),
-        t.coinbase_value
+        t.coinbase_value,
+        t.transactions.iter().map(|tx| tx.sigops as u64).sum::<u64>(),
     );
 
     metrics::STAT_CURRENT_TEMPLATE_TRANSACTIONS_GAUGE.set(t.transactions.len() as i64);

--- a/daemon/src/metrics.rs
+++ b/daemon/src/metrics.rs
@@ -44,6 +44,10 @@ lazy_static! {
     pub static ref STAT_CURRENT_TEMPLATE_COINBASE_VALUE_GAUGE: IntGauge =
         register_int_gauge!(format!("{}_stats_current_template_coinbase_value_sat", PREFIX), "Output value of the coinbase transaction in the block template.").unwrap();
 
+    /// Sigops in the most recently queried block template.
+    pub static ref STAT_CURRENT_TEMPLATE_SIGOPS_GAUGE: IntGauge =
+        register_int_gauge!(format!("{}_stats_current_template_sigops", PREFIX), "Sigops of the transactions in the block template.").unwrap();
+
     /// Number of conflicting transaction sets between template and block.
     pub static ref STAT_CONFLICTING_TRANSACTION_SETS: IntCounter =
         register_int_counter!(format!("{}_stats_conflicting_transaction_sets", PREFIX), "Total number of processed conflicting transaction sets.").unwrap();

--- a/daemon/src/processing.rs
+++ b/daemon/src/processing.rs
@@ -758,6 +758,11 @@ pub fn build_block(
         template_cb_fees: template_fees.to_sat() as i64,
         template_pkg_weights: template_pkg_weights.to_vec(),
         template_pkg_feerates: template_pkg_feerates.to_vec(),
+        template_sigops: template
+            .transactions
+            .iter()
+            .map(|tx| tx.sigops as u64)
+            .sum::<u64>() as i64,
     }
 }
 

--- a/migrations/2023-04-08-105025_add_template_sigops_to_block_table/down.sql
+++ b/migrations/2023-04-08-105025_add_template_sigops_to_block_table/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE block DROP COLUMN template_sigops;

--- a/migrations/2023-04-08-105025_add_template_sigops_to_block_table/up.sql
+++ b/migrations/2023-04-08-105025_add_template_sigops_to_block_table/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE block ADD "template_sigops" BIGINT NOT NULL DEFAULT 0;

--- a/shared/src/model.rs
+++ b/shared/src/model.rs
@@ -57,6 +57,7 @@ pub struct Block {
     pub template_weight: i32,
     pub template_pkg_weights: Vec<i64>,
     pub template_pkg_feerates: Vec<f32>,
+    pub template_sigops: i64,
 }
 
 /// This is used to construct a [Block] for insertion into the database.
@@ -103,6 +104,7 @@ pub struct NewBlock {
     pub template_weight: i32,
     pub template_pkg_weights: Vec<i64>,
     pub template_pkg_feerates: Vec<f32>,
+    pub template_sigops: i64,
 }
 
 #[derive(Debug, Insertable, Queryable, Serialize, Clone)]

--- a/shared/src/schema.patch
+++ b/shared/src/schema.patch
@@ -7,7 +7,7 @@ diff --git a/shared/src/schema.rs b/shared/src/schema.rs
 index 8b77f0a..8d5a1a1 100644
 --- a/shared/src/schema.rs
 +++ b/shared/src/schema.rs
-@@ -3,48 +3,48 @@
+@@ -3,49 +3,49 @@
  diesel::table! {
      block (hash) {
          id -> Int4,
@@ -45,6 +45,7 @@ index 8b77f0a..8d5a1a1 100644
 -        template_pkg_feerates -> Array<Nullable<Float4>>,
 +        template_pkg_weights -> Array<Int8>,
 +        template_pkg_feerates -> Array<Float4>,
+         template_sigops -> Int8,
      }
  }
  

--- a/shared/src/schema.rs
+++ b/shared/src/schema.rs
@@ -32,6 +32,7 @@ diesel::table! {
         template_weight -> Int4,
         template_pkg_weights -> Array<Int8>,
         template_pkg_feerates -> Array<Float4>,
+        template_sigops -> Int8,
     }
 }
 

--- a/www/templates/macro/template_and_block.html
+++ b/www/templates/macro/template_and_block.html
@@ -19,6 +19,9 @@
                 {{ block::info_col(label="packages", value=var_pkgs_template, value_extra="") }}
                 {{ block::info_col(label="fees", value=block.template_cb_fees / 100000000, value_extra=" BTC") }}
                 {{ block::info_col(label="creation time", value=block.template_time | date(format="%Y-%m-%d %H:%M:%S UTC"), value_extra="") }}
+                {% if block.template_sigops > 0 %}
+                  {{ block::info_col(label="sigops", value=block.template_sigops, value_extra="") }}
+                {% endif %}
             </div>
         </div>
 


### PR DESCRIPTION
This adds the sigops of queried block templates to the to the template information log outputs, saves them in the database which allows showing them on the "template & block" page, and adds a Prometheus metric for the template sigops.

Recently, two blocks were mined by F2Pool which were invalid due to having a few extra sigops (80_000 is the maximum per consensus rules). This provides more information about how many sigops were in a Bitcoin Core block template at that point.

We don't have sigops counts for old templates. Sigops will only be displayed for new templates. 

closes #61 