### PR TITLE
fix: pin rawtx-rs to v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1676,8 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "rawtx-rs"
-version = "0.1.0"
-source = "git+https://github.com/0xB10C/rawtx-rs?branch=master#d7b84698413b3596c4374521f3936bec2d8b9b9e"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0a66a01bd372d271993c8f48f0644be7050ddcf2eb575e53f6e750858624be"
 dependencies = [
  "bitcoin",
  "hex",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -14,7 +14,7 @@ simple_logger = "1.9.0"
 
 bitcoin = "0.29"
 bitcoin-pool-identification = "0.1.12"
-rawtx-rs = {git = "https://github.com/0xB10C/rawtx-rs", branch = "master", features = [ "counterparty" ]}
+rawtx-rs = { version = "0.1.1", features = [ "counterparty" ]}
 
 hex = "0.4"
 


### PR DESCRIPTION
The rawtx-rs crate was build from master before. As the master branch of rawtx-rs is now on rust-bitcoin 0.30, building miningpool-observer fails.