### PR TITLE
Store and show sigops for transactions blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "rawtx-rs"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399d7e1c351176186585630e173e05b97d17c3436dcc2faf3794b465bef2e230"
+checksum = "74a5171c76983382ec1301428821fbfa14e2fa6d84b131704ff56195cbd05c3b"
 dependencies = [
  "bitcoin",
  "hex",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -14,7 +14,7 @@ simple_logger = "1.9.0"
 
 bitcoin = "0.30"
 bitcoin-pool-identification = "0.2.4"
-rawtx-rs = { version = "0.1.2", features = [ "counterparty" ]}
+rawtx-rs = { version = "0.1.4", features = [ "counterparty" ]}
 
 hex = "0.4"
 

--- a/daemon/src/processing.rs
+++ b/daemon/src/processing.rs
@@ -14,7 +14,9 @@ use miningpool_observer_shared::{model as shared_model, tags};
 
 use bitcoin_pool_identification::{IdentificationMethod, PoolIdentification};
 use rawtx_rs::tx::TxInfo as RawTxInfo;
-use rawtx_rs::tx::{is_opreturn_counterparty, is_p2ms_counterparty, is_p2sh_counterparty};
+use rawtx_rs::tx::{
+    is_opreturn_counterparty, is_p2ms_counterparty, is_p2sh_counterparty, TransactionSigops,
+};
 use rawtx_rs::{input::InputType, output::OutputType};
 
 use bitcoin::hash_types::Txid;
@@ -426,6 +428,7 @@ pub fn build_transaction(
         inputs: inputs_strs,
         output_count: tx_info.tx.output.len() as i32,
         outputs: outputs_strs,
+        sigops: tx_info.tx.sigops().unwrap_or_default() as i64,
     });
 }
 
@@ -777,6 +780,11 @@ pub fn build_block(
             .iter()
             .map(|tx| tx.sigops as u64)
             .sum::<u64>() as i64,
+        block_sigops: block
+            .txdata
+            .iter()
+            .map(|tx| tx.sigops().unwrap_or_default() as i64)
+            .sum(),
     }
 }
 

--- a/migrations/2023-04-10-204659_add_remaining_sigops_fields/down.sql
+++ b/migrations/2023-04-10-204659_add_remaining_sigops_fields/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE block DROP COLUMN block_sigops;
+
+ALTER TABLE transaction DROP COLUMN sigops;

--- a/migrations/2023-04-10-204659_add_remaining_sigops_fields/up.sql
+++ b/migrations/2023-04-10-204659_add_remaining_sigops_fields/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE block ADD "block_sigops" BIGINT NOT NULL DEFAULT 0;
+
+ALTER TABLE transaction ADD "sigops" BIGINT NOT NULL DEFAULT -1;

--- a/shared/src/model.rs
+++ b/shared/src/model.rs
@@ -58,6 +58,7 @@ pub struct Block {
     pub template_pkg_weights: Vec<i64>,
     pub template_pkg_feerates: Vec<f32>,
     pub template_sigops: i64,
+    pub block_sigops: i64,
 }
 
 /// This is used to construct a [Block] for insertion into the database.
@@ -105,6 +106,7 @@ pub struct NewBlock {
     pub template_pkg_weights: Vec<i64>,
     pub template_pkg_feerates: Vec<f32>,
     pub template_sigops: i64,
+    pub block_sigops: i64,
 }
 
 #[derive(Debug, Insertable, Queryable, Serialize, Clone)]
@@ -121,6 +123,7 @@ pub struct Transaction {
     pub inputs: Vec<String>,
     pub output_count: i32,
     pub outputs: Vec<String>,
+    pub sigops: i64,
 }
 
 impl Hash for Transaction {

--- a/shared/src/schema.patch
+++ b/shared/src/schema.patch
@@ -7,7 +7,7 @@ diff --git a/shared/src/schema.rs b/shared/src/schema.rs
 index 8b77f0a..8d5a1a1 100644
 --- a/shared/src/schema.rs
 +++ b/shared/src/schema.rs
-@@ -3,49 +3,49 @@
+@@ -3,50 +3,50 @@
  diesel::table! {
      block (hash) {
          id -> Int4,
@@ -46,6 +46,7 @@ index 8b77f0a..8d5a1a1 100644
 +        template_pkg_weights -> Array<Int8>,
 +        template_pkg_feerates -> Array<Float4>,
          template_sigops -> Int8,
+         block_sigops -> Int8,
      }
  }
  
@@ -81,7 +82,7 @@ index 8b77f0a..8d5a1a1 100644
  diesel::table! {
      sanctioned_utxo (txid, vout) {
          txid -> Bytea,
-@@ -97,17 +97,17 @@ diesel::table! {
+@@ -97,18 +97,18 @@ diesel::table! {
      transaction (txid) {
          txid -> Bytea,
          sanctioned -> Bool,
@@ -96,6 +97,7 @@ index 8b77f0a..8d5a1a1 100644
          output_count -> Int4,
 -        outputs -> Array<Nullable<Text>>,
 +        outputs -> Array<Text>,
+         sigops -> Int8,
      }
  }
  

--- a/shared/src/schema.rs
+++ b/shared/src/schema.rs
@@ -33,6 +33,7 @@ diesel::table! {
         template_pkg_weights -> Array<Int8>,
         template_pkg_feerates -> Array<Float4>,
         template_sigops -> Int8,
+        block_sigops -> Int8,
     }
 }
 
@@ -112,6 +113,7 @@ diesel::table! {
         inputs -> Array<Text>,
         output_count -> Int4,
         outputs -> Array<Text>,
+        sigops -> Int8,
     }
 }
 

--- a/web/src/util.rs
+++ b/web/src/util.rs
@@ -54,7 +54,16 @@ pub fn tx_tag_id_to_tag() -> impl tera::Function {
         move |args: &HashMap<String, tera::Value>| -> tera::Result<tera::Value> {
             match args.get("id") {
                 Some(val) => match tera::from_value::<i32>(val.clone()) {
-                    Ok(v) => Ok(tera::to_value(tags::TxTag::try_from(v).unwrap().value()).unwrap()),
+                    Ok(v) => {
+                        match tags::TxTag::try_from(v) {
+                            Ok(v) => {
+                                Ok(tera::to_value(v.value()).unwrap())
+                            },
+                            Err(e) => {
+                                Err(format!("Could not find TxTag for value {:?}. Is the mapping implemented?: {:?}", v, e).into())
+                            }
+                        }
+                    }
                     Err(_) => Err(format!("Can't parse 'id' with val={} as i32.", val).into()),
                 },
                 None => Err("No parameter 'id' passed to tag_id_to_tag()".into()),
@@ -69,7 +78,14 @@ pub fn block_tag_id_to_tag() -> impl tera::Function {
             match args.get("id") {
                 Some(val) => match tera::from_value::<i32>(val.clone()) {
                     Ok(v) => {
-                        Ok(tera::to_value(tags::BlockTag::try_from(v).unwrap().value()).unwrap())
+                        match tags::BlockTag::try_from(v) {
+                            Ok(v) => {
+                                Ok(tera::to_value(v.value()).unwrap())
+                            },
+                            Err(e) => {
+                                Err(format!("Could not find BlockTag for value {:?}. Is the mapping implemented?: {:?}", v, e).into())
+                            }
+                        }
                     }
                     Err(_) => Err(format!("Can't parse 'id' with val={} as i32.", val).into()),
                 },

--- a/www/templates/macro/missing.html
+++ b/www/templates/macro/missing.html
@@ -11,6 +11,9 @@
             {{ transaction::info_col(label="feerate", value=missing.transaction.fee / missing.transaction.vsize | round(method="ceil", precision=2), value_extra=" sat/vByte") }}
             {{ transaction::info_col(label="vsize", value=missing.transaction.vsize, value_extra=" vByte") }}
             {{ transaction::info_col(label="output sum", value=missing.transaction.output_sum / 100000000, value_extra=" BTC") }}
+            {% if missing.transaction.sigops > 0 %}
+              {{ transaction::info_col(label="sigops", value=missing.transaction.sigops, value_extra="") }}
+            {% endif %}
             {{ transaction::inputs(ins=missing.transaction.inputs, count=missing.transaction.input_count) }}
             {{ transaction::outputs(outs=missing.transaction.outputs, count=missing.transaction.output_count) }}
         </div>

--- a/www/templates/macro/template_and_block.html
+++ b/www/templates/macro/template_and_block.html
@@ -7,6 +7,7 @@
         {% set var_fees_diff = (block.block_cb_fees - block.template_cb_fees) / 100000 %}
         {% set var_weight_diff = block.block_weight - block.template_weight %}
         {% set var_sanctioned_diff = block.block_sanctioned - block.template_sanctioned %}
+        {% set var_sigops_diff = block.block_sigops - block.template_sigops %}
 
         <div class="col my-2 my-md-0">
             <div class="row row-cols-1">
@@ -36,6 +37,9 @@
                 {{ block::info_col_with_diff(label="packages", value=var_pkgs_block, value_extra="", diff=var_pkgs_diff, diff_extra="") }}
                 {{ block::info_col_with_diff(label="fees", value=block.block_cb_fees / 100000000, value_extra=" BTC", diff=var_fees_diff, diff_extra=" mBTC") }}
                 {{ block::info_col(label="miner-set time", value=block.block_time | date(format="%Y-%m-%d %H:%M:%S UTC"), value_extra="") }}
+                {% if block.block_sigops > 0 %}
+                    {{ block::info_col_with_diff(label="sigops", value=block.block_sigops, value_extra="", diff=var_sigops_diff, diff_extra="") }}
+                {% endif %}
             </div>
         </div>
 

--- a/www/templates/macro/transaction.html
+++ b/www/templates/macro/transaction.html
@@ -18,6 +18,9 @@
             {{ transaction::info_col(label="feerate", value=tx.1.fee / tx.1.vsize | round(method="ceil", precision=2), value_extra=" sat/vByte") }}
             {{ transaction::info_col(label="vsize", value=tx.1.vsize, value_extra=" vByte") }}
             {{ transaction::info_col(label="output sum", value=tx.1.output_sum / 100000000, value_extra=" BTC") }}
+            {% if tx.1.sigops >= 0 %}
+                {{ transaction::info_col(label="sigops", value=tx.1.sigops, value_extra="") }}
+            {% endif %}
             {{ transaction::inputs(ins=tx.1.inputs, count=tx.1.input_count) }}
             {{ transaction::outputs(outs=tx.1.outputs, count=tx.1.output_count) }}
             {% if place == "template" %}


### PR DESCRIPTION
Currently, only sigops for templates are stored and shown.