### PR TITLE
Performance improvements for /missing

### DIFF
--- a/web/src/db.rs
+++ b/web/src/db.rs
@@ -425,8 +425,6 @@ const QUERY_MISSING_TRANSACTIONS: &str = r#"
         max(block_id) max_block_id,
         transaction_txid txid
     FROM transaction_only_in_template
-    JOIN transaction
-        ON transaction.txid = transaction_txid
     JOIN block
 	    on block.id = block_id
     WHERE

--- a/web/src/db.rs
+++ b/web/src/db.rs
@@ -431,6 +431,8 @@ const QUERY_MISSING_TRANSACTIONS: &str = r#"
 	    transaction_only_in_template.position < (block.template_tx - block.template_tx * 0.02)
 	    AND
 	    block.block_tx > 1
+        AND
+	    block_id > (SELECT max(block_id) FROM transaction_only_in_template) - 20000
     GROUP BY transaction_txid
     HAVING
         count(*) > 2
@@ -455,6 +457,8 @@ const QUERY_COUNT_MISSING_TRANSACTIONS: &str = r#"
                 transaction_only_in_template.position < (block.template_tx - block.template_tx * 0.02)
                 AND
                 block.block_tx > 1
+                AND
+	            block_id > (SELECT max(block_id) FROM transaction_only_in_template) - 20000
             GROUP BY transaction_txid
             HAVING
                 COUNT(transaction_txid) > 2


### PR DESCRIPTION
This optimizes the SQL queries a bit. However, it also reduces the (very old) data we'd potentially show to the user.

Another option could be [Materialized Views](https://www.postgresql.org/docs/current/rules-materializedviews.html) that are refreshed on every block (i.e. every time we insert new data). This would take more effort to implement. Maybe something for the future.

fixes https://github.com/0xB10C/miningpool-observer/issues/69