### PR TITLE
fix: build tx packages similar to Bitcoin Core

### DIFF
--- a/daemon/src/model.rs
+++ b/daemon/src/model.rs
@@ -1,4 +1,3 @@
-use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 
 use bitcoin::hash_types::Txid;
@@ -16,6 +15,14 @@ pub struct TxInfo {
 impl TxInfo {
     pub fn feerate(&self) -> f32 {
         self.fee.to_sat() as f32 / self.tx.vsize() as f32
+    }
+
+    pub fn prev_output_txids(&self) -> HashSet<Txid> {
+        self.tx
+            .input
+            .iter()
+            .map(|input| input.previous_output.txid)
+            .collect()
     }
 }
 
@@ -35,26 +42,6 @@ impl TxPackage {
             .iter()
             .map(|i| i.tx.weight().to_wu() as usize)
             .sum::<usize>()
-    }
-}
-
-#[derive(PartialEq, Eq, Clone)]
-pub struct TxPackageForPackageConstruction {
-    pub txns: RefCell<Vec<TxInfo>>,
-}
-
-impl TxPackageForPackageConstruction {
-    pub fn min_tx_pos(&self) -> i32 {
-        self.txns
-            .borrow()
-            .iter()
-            .map(|tx_info| tx_info.pos)
-            .min()
-            .unwrap_or(-1)
-    }
-
-    pub fn txids(&self) -> HashSet<Txid> {
-        self.txns.borrow().iter().map(|t| t.txid).collect()
     }
 }
 

--- a/www/templates/subpage/template_and_block.html
+++ b/www/templates/subpage/template_and_block.html
@@ -80,7 +80,6 @@
             </div>
         </noscript>
     </div>
-    <span class="text-muted small">Note: The graph might contain package ordering artifacts from transaction package construction. The packages are purposefully not sorted by feerate to show custom pool prioritizations (if present).</span>
 </div>
 
 <div class="my-3 p-3 bg-white shadow-sm"> 


### PR DESCRIPTION
The previous implementation build packages with a global view of the available transactions. This is different from how Bitcoin Core inserts packages into a block template. For smoother feerate distribution plots, the package building algorithm changed to only account for local packages (i.e. transactions next to each other in the block). This also simplifies the package building function as a whole.

before: 
![image](https://github.com/0xB10C/miningpool-observer/assets/19157360/148fd319-a215-43f8-acdb-0089ee5e8cf4)

after:
![image](https://github.com/0xB10C/miningpool-observer/assets/19157360/51816cb1-6778-4ea2-a35d-e1800e1fdd49)
