### PR TITLE
update rawtx-rs and bitcoin-pool-identification dependecies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,8 +337,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
 dependencies = [
- "bitcoin-internals 0.3.0",
- "bitcoin_hashes 0.14.0",
+ "bitcoin-internals",
+ "bitcoin_hashes",
 ]
 
 [[package]]
@@ -355,29 +355,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bech32"
-version = "0.10.0-beta"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
-
-[[package]]
-name = "bech32"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
-
-[[package]]
-name = "bitcoin"
-version = "0.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c85783c2fe40083ea54a33aa2f0ba58831d90fcd190f5bdc47e74e84d2a96ae"
-dependencies = [
- "bech32 0.10.0-beta",
- "bitcoin-internals 0.2.0",
- "bitcoin_hashes 0.13.0",
- "hex-conservative 0.1.2",
- "hex_lit",
- "secp256k1 0.28.2",
-]
 
 [[package]]
 name = "bitcoin"
@@ -386,22 +366,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
 dependencies = [
  "base58ck",
- "bech32 0.11.0",
- "bitcoin-internals 0.3.0",
+ "bech32",
+ "bitcoin-internals",
  "bitcoin-io",
  "bitcoin-units",
- "bitcoin_hashes 0.14.0",
- "hex-conservative 0.2.1",
+ "bitcoin_hashes",
+ "hex-conservative",
  "hex_lit",
- "secp256k1 0.29.1",
+ "secp256k1",
  "serde",
 ]
-
-[[package]]
-name = "bitcoin-internals"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
 
 [[package]]
 name = "bitcoin-internals"
@@ -424,7 +398,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e45666963cd40869f6012d6d04b613bff7f844523d3d39a78ed38fe6c9cd13c1"
 dependencies = [
- "bitcoin 0.32.5",
+ "bitcoin",
  "hex",
  "serde",
  "serde_json",
@@ -436,18 +410,8 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
 dependencies = [
- "bitcoin-internals 0.3.0",
+ "bitcoin-internals",
  "serde",
-]
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
-dependencies = [
- "bitcoin-internals 0.2.0",
- "hex-conservative 0.1.2",
 ]
 
 [[package]]
@@ -457,7 +421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
 dependencies = [
  "bitcoin-io",
- "hex-conservative 0.2.1",
+ "hex-conservative",
  "serde",
 ]
 
@@ -478,7 +442,7 @@ name = "bitcoincore-rpc-json"
 version = "0.19.0"
 source = "git+https://github.com/0xb10c/rust-bitcoincore-rpc?branch=mpo-0.19#2450c46ee7a2f87e961f1686aa8365619fb7ebda"
 dependencies = [
- "bitcoin 0.32.5",
+ "bitcoin",
  "serde",
  "serde_json",
 ]
@@ -1074,12 +1038,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hex-conservative"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
 
 [[package]]
 name = "hex-conservative"
@@ -1829,14 +1787,13 @@ dependencies = [
 
 [[package]]
 name = "rawtx-rs"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9dcea607a8587cd0fb7e143a3cd1b6a5fa1989ecd6a17808ec92444aa552604"
+checksum = "e8432d3f46efc3d58e74ef4d2dcdc4da7425625dab86e3df293e2d799419d3eb"
 dependencies = [
- "bitcoin 0.31.2",
+ "bitcoin",
  "hex",
  "rc4",
- "secp256k1 0.19.0",
 ]
 
 [[package]]
@@ -2060,51 +2017,14 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6179428c22c73ac0fbb7b5579a56353ce78ba29759b3b8575183336ea74cdfb"
-dependencies = [
- "secp256k1-sys 0.3.0",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
-dependencies = [
- "bitcoin_hashes 0.13.0",
- "secp256k1-sys 0.9.2",
-]
-
-[[package]]
-name = "secp256k1"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes 0.14.0",
+ "bitcoin_hashes",
  "rand",
- "secp256k1-sys 0.10.1",
+ "secp256k1-sys",
  "serde",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11553d210db090930f4432bea123b31f70bbf693ace14504ea2a35e796c28dd2"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "base58ck"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+dependencies = [
+ "bitcoin-internals 0.3.0",
+ "bitcoin_hashes 0.14.0",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,17 +360,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
 
 [[package]]
+name = "bech32"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
+
+[[package]]
 name = "bitcoin"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c85783c2fe40083ea54a33aa2f0ba58831d90fcd190f5bdc47e74e84d2a96ae"
 dependencies = [
- "bech32",
- "bitcoin-internals",
- "bitcoin_hashes",
- "hex-conservative",
+ "bech32 0.10.0-beta",
+ "bitcoin-internals 0.2.0",
+ "bitcoin_hashes 0.13.0",
+ "hex-conservative 0.1.2",
  "hex_lit",
  "secp256k1 0.28.2",
+]
+
+[[package]]
+name = "bitcoin"
+version = "0.32.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
+dependencies = [
+ "base58ck",
+ "bech32 0.11.0",
+ "bitcoin-internals 0.3.0",
+ "bitcoin-io",
+ "bitcoin-units",
+ "bitcoin_hashes 0.14.0",
+ "hex-conservative 0.2.1",
+ "hex_lit",
+ "secp256k1 0.29.1",
  "serde",
 ]
 
@@ -369,20 +402,42 @@ name = "bitcoin-internals"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "bitcoin-pool-identification"
-version = "0.3.3"
+name = "bitcoin-io"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c992051589605da0d01d6c754da6ad9d4727fe604dd334fdc14b9cf0e75af407"
+checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+
+[[package]]
+name = "bitcoin-pool-identification"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45666963cd40869f6012d6d04b613bff7f844523d3d39a78ed38fe6c9cd13c1"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.32.5",
  "hex",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "bitcoin-units"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
+dependencies = [
+ "bitcoin-internals 0.3.0",
+ "serde",
 ]
 
 [[package]]
@@ -391,15 +446,25 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
 dependencies = [
- "bitcoin-internals",
- "hex-conservative",
+ "bitcoin-internals 0.2.0",
+ "hex-conservative 0.1.2",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative 0.2.1",
  "serde",
 ]
 
 [[package]]
 name = "bitcoincore-rpc"
-version = "0.18.0"
-source = "git+https://github.com/0xb10c/rust-bitcoincore-rpc?branch=mpo-0.18#b43f9fd53b337d8327cbfb226c2850a178a880ea"
+version = "0.19.0"
+source = "git+https://github.com/0xb10c/rust-bitcoincore-rpc?branch=mpo-0.19#2450c46ee7a2f87e961f1686aa8365619fb7ebda"
 dependencies = [
  "bitcoincore-rpc-json",
  "jsonrpc",
@@ -410,10 +475,10 @@ dependencies = [
 
 [[package]]
 name = "bitcoincore-rpc-json"
-version = "0.18.0"
-source = "git+https://github.com/0xb10c/rust-bitcoincore-rpc?branch=mpo-0.18#b43f9fd53b337d8327cbfb226c2850a178a880ea"
+version = "0.19.0"
+source = "git+https://github.com/0xb10c/rust-bitcoincore-rpc?branch=mpo-0.19#2450c46ee7a2f87e961f1686aa8365619fb7ebda"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.32.5",
  "serde",
  "serde_json",
 ]
@@ -1017,6 +1082,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec 0.7.6",
+]
+
+[[package]]
 name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,11 +1266,12 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc"
-version = "0.14.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8128f36b47411cd3f044be8c1f5cc0c9e24d1d1bfdc45f0a57897b32513053f2"
+checksum = "3662a38d341d77efecb73caf01420cfa5aa63c0253fd7bc05289ef9f6616e1bf"
 dependencies = [
  "base64 0.13.1",
+ "minreq",
  "serde",
  "serde_json",
 ]
@@ -1403,6 +1478,8 @@ dependencies = [
  "once_cell",
  "rustls",
  "rustls-webpki",
+ "serde",
+ "serde_json",
  "webpki-roots",
 ]
 
@@ -1756,7 +1833,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9dcea607a8587cd0fb7e143a3cd1b6a5fa1989ecd6a17808ec92444aa552604"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.31.2",
  "hex",
  "rc4",
  "secp256k1 0.19.0",
@@ -1996,9 +2073,19 @@ version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
 dependencies = [
- "bitcoin_hashes",
- "rand",
+ "bitcoin_hashes 0.13.0",
  "secp256k1-sys 0.9.2",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
+dependencies = [
+ "bitcoin_hashes 0.14.0",
+ "rand",
+ "secp256k1-sys 0.10.1",
  "serde",
 ]
 
@@ -2016,6 +2103,15 @@ name = "secp256k1-sys"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -13,7 +13,7 @@ log = "0.4"
 simple_logger = "1.9.0"
 
 bitcoin-pool-identification = "0.3.3"
-rawtx-rs = { version = "0.1.8", features = [ "counterparty" ]}
+rawtx-rs = { version = "0.1.12", features = [ "counterparty" ]}
 
 hex = "0.4"
 

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -13,7 +13,7 @@ log = "0.4"
 simple_logger = "1.9.0"
 
 bitcoin-pool-identification = "0.3.4"
-rawtx-rs = { version = "0.1.12", features = [ "counterparty" ]}
+rawtx-rs = { version = "0.1.13", features = [ "counterparty" ]}
 
 hex = "0.4"
 

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -12,7 +12,7 @@ miningpool_observer_shared = { path="../shared" }
 log = "0.4"
 simple_logger = "1.9.0"
 
-bitcoin-pool-identification = "0.3.3"
+bitcoin-pool-identification = "0.3.4"
 rawtx-rs = { version = "0.1.12", features = [ "counterparty" ]}
 
 hex = "0.4"

--- a/daemon/src/processing.rs
+++ b/daemon/src/processing.rs
@@ -335,7 +335,7 @@ fn get_pool_info_or_default(
 /// Builds a vector of transaction packages. These Packages are similar to what
 /// Bitcoin Core (currently) puts into blocks.
 pub fn build_packages(txns: &[TxInfo]) -> Vec<TxPackage> {
-    let txids_in_txns: HashSet<Txid> = txns.iter().map(|ti| ti.tx.txid()).collect();
+    let txids_in_txns: HashSet<Txid> = txns.iter().map(|ti| ti.tx.compute_txid()).collect();
     let mut packages: Vec<TxPackage> = vec![];
 
     // Bitcoin Core places transactions that belong to a package next to each other.
@@ -355,7 +355,7 @@ pub fn build_packages(txns: &[TxInfo]) -> Vec<TxPackage> {
                     txids.extend(&tx.prev_output_txids());
                     txids
                 });
-            if parent_txids.contains(&tx_info.tx.txid()) {
+            if parent_txids.contains(&tx_info.tx.compute_txid()) {
                 // belongs to the same package if the tx is a parent of a tx in the package
                 package_txns.push(tx_info.clone());
             } else if tx_info
@@ -601,7 +601,7 @@ pub fn build_newly_created_sanctioned_utxos(
                         script_pubkey: output.script_pubkey.to_bytes(),
                         height: block.bip34_block_height().unwrap_or_default() as i32,
                         txid: to_sanctioned_tx
-                            .txid()
+                            .compute_txid()
                             .to_byte_array()
                             .to_vec()
                             .iter()
@@ -631,7 +631,7 @@ pub fn build_block_tx_data(
         .collect();
 
     for (i, tx) in block.txdata.iter().enumerate() {
-        let txid = tx.txid();
+        let txid = tx.compute_txid();
         txids.insert(txid);
         let tx_info = TxInfo {
             txid,
@@ -666,9 +666,9 @@ pub fn build_template_tx_data(template: &GetBlockTemplateResult) -> TemplateTxDa
                 continue;
             }
         };
-        txids.insert(deser_tx.txid());
+        txids.insert(deser_tx.compute_txid());
         let tx_info = TxInfo {
-            txid: deser_tx.txid(),
+            txid: deser_tx.compute_txid(),
             tx: deser_tx,
             pos: i as i32,
             fee: tx.fee,
@@ -1188,7 +1188,7 @@ mod tests {
         let tx_a_info = TxInfo {
             fee: tx_a.fee,
             pos: 0,
-            txid: tx_a.tx.txid(),
+            txid: tx_a.tx.compute_txid(),
             tx: tx_a.tx,
         };
 
@@ -1202,7 +1202,7 @@ mod tests {
         let tx_b_info = TxInfo {
             fee: tx_b.fee,
             pos: 1,
-            txid: tx_b.tx.txid(),
+            txid: tx_b.tx.compute_txid(),
             tx: tx_b.tx,
         };
 
@@ -1216,7 +1216,7 @@ mod tests {
         let tx_c_info = TxInfo {
             fee: tx_c.fee,
             pos: 2,
-            txid: tx_c.tx.txid(),
+            txid: tx_c.tx.compute_txid(),
             tx: tx_c.tx,
         };
 
@@ -1230,7 +1230,7 @@ mod tests {
         let tx_d_info = TxInfo {
             fee: tx_d.fee,
             pos: 2,
-            txid: tx_d.tx.txid(),
+            txid: tx_d.tx.compute_txid(),
             tx: tx_d.tx,
         };
 
@@ -1287,7 +1287,7 @@ mod tests {
         let tx_e_info = TxInfo {
             fee: Amount::from_sat(2),
             pos: 3,
-            txid: tx_e.txid(),
+            txid: tx_e.compute_txid(),
             tx: tx_e.clone(),
         };
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -15,4 +15,4 @@ chrono = { version = "0.4", features = ["serde"] }
 
 # Requirements to switch to upstream rust-bitcoincore-rpc:
 # - some way of getting the fees from getblock with verbosity 2, currently only a minimal implementation in the mpo branch
-bitcoincore-rpc = { git = "https://github.com/0xb10c/rust-bitcoincore-rpc", branch = "mpo-0.18" }
+bitcoincore-rpc = { git = "https://github.com/0xb10c/rust-bitcoincore-rpc", branch = "mpo-0.19" }


### PR DESCRIPTION
Next to general house keeping, this also enables compatibility with Bitcoin Core v28.