### PR TITLE
add: /missing-sanctioned page

### DIFF
--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -129,6 +129,15 @@ async fn main() -> std::io::Result<()> {
                 "/og_image/missing/{txid}.png",
                 web::get().to(ogimage::ogimage_missing_transaction),
             )
+            // MISSING SANCTIONED
+            .route(
+                "/missing-sanctioned",
+                web::get().to(handler::missing_sanctioned),
+            )
+            .route(
+                "/og_image/missing-sanctioned.png",
+                web::get().to(ogimage::ogimage_mainpage_sanctioned_transactions),
+            )
             //
             // CONFLICTING TRANSACTION PAGES
             //

--- a/web/src/ogimage.rs
+++ b/web/src/ogimage.rs
@@ -287,6 +287,31 @@ pub async fn ogimage_mainpage_conflicting_transactions(
     }
 }
 
+pub async fn ogimage_mainpage_sanctioned_transactions(
+    config: web::Data<config::WebSiteConfig>,
+    usvg_opts: web::Data<usvg::Options>,
+    tmpl: web::Data<tera::Tera>,
+) -> Result<HttpResponse, Error> {
+    let mut ctx = tera::Context::new();
+    ctx.insert("config", config.get_ref());
+    let s = tmpl
+        .render("svg/mainpage_sanctioned_transactions.svg", &ctx)
+        .map_err(error::template_error)?;
+
+    match render_and_encode(&s, usvg_opts.get_ref()) {
+        Ok(png_data) => Ok(HttpResponse::Ok().content_type("image/png").body(png_data)),
+        Err(e) => {
+            log::error!(
+                "Could not render og::image mainpage_sanctioned_transactions: {}",
+                e
+            );
+            Err(actix_error::ErrorInternalServerError(
+                "Render or Encoding Error",
+            ))
+        }
+    }
+}
+
 pub async fn ogimage_mainpage_index(
     config: web::Data<config::WebSiteConfig>,
     usvg_opts: web::Data<usvg::Options>,

--- a/www/templates/index.html
+++ b/www/templates/index.html
@@ -96,6 +96,20 @@
               <a class="stretched-link" href="{{CONFIG.base_url}}/conflicting"></a>
             </div>
             <div class="col position-relative grow-on-hover">
+              <div class="card h-100 shadow-sm">
+                <img src="/static/img/block-sanctioned.svg" width="120" height="120" class="card-img-top p-3 border-bottom" alt="Sanctioned Transactions">
+                <div class="card-body">
+                    <h4 class="card-title">Sanctioned Transactions</h4>
+                    <h6 class="card-subtitle mb-2 text-muted">Sanctioned transactions missing from Blocks</h6>
+                    <p class="card-text">
+                      When a sanctioned transaction is missing from a block, it can be - but doesn't have to be - an indication that a mining pool is filtering these.
+                      This page lists sanctioned transactions missing from blocks.
+                    </p>
+                </div>
+              </div>
+              <a class="stretched-link" href="{{CONFIG.base_url}}/missing-sanctioned"></a>
+            </div>
+            <div class="col position-relative grow-on-hover">
                 <div class="card h-100 shadow-sm">
                   <img src="/static/img/faq.svg" width="120" height="120" class="card-img-top p-3 border-bottom" alt="Conflicting Transactions">
                   <div class="card-body">

--- a/www/templates/macro/template_and_block.html
+++ b/www/templates/macro/template_and_block.html
@@ -107,7 +107,7 @@
 
 {% macro sanctioned(block) %}
     {% if block.sanctioned_missing_tx > 0 %}
-        <div class="alert alert-warning text-center mt-2" role="alert">
+        <div class="alert alert-danger text-center mt-2" role="alert">
             <p class="mb-0">
                 The block template includes <strong>{{block.sanctioned_missing_tx}} sanctioned transaction{{ block.sanctioned_missing_tx | pluralize }}</strong> which {{ block.sanctioned_missing_tx | pluralize(singular="is", plural="are") }} not present in the block.
                 <br>

--- a/www/templates/missing-sanctioned.html
+++ b/www/templates/missing-sanctioned.html
@@ -1,0 +1,66 @@
+{% extends "base.html" %}
+
+{% import "macro/template_and_block.html" as block %}
+{% import "macro/opengraph.html" as opengraph %}
+
+{% block opengraph %}
+{{
+    opengraph::og(
+        title="Missing Sanctioned Transaction",
+        description="Sanctioned Transactions Missing from Blocks",
+        url="/missing-sanctioned",
+        image_url="/og_image/missing-sanctioned.png"
+    )
+}}
+{% endblock opengraph %}
+
+{% block content %}
+<section>
+    <div class="bg-white p-3 mb-4">
+        <h1>
+            Missing Sanctioned Transactions
+        </h1>
+
+        <p>
+            This page lists blocks where one or more <a href="{{CONFIG.base_url}}/faq#sanctioned">sanctioned transactions</a> are missing from a block.
+            While frequent missing sanctioned can be an indication that a mining pool filters these, there can be false positives.
+            Detailed analysis like <a href="https://b10c.me/observations/08-missing-sanctioned-transactions/">this</a> (November 2023)
+            or <a href="https://b10c.me/observations/13-missing-sanctioned-transactions-2024-12/">this</a> (January 2025) might be needed first.
+        </p>
+
+        {% if ENTRY_COUNT == 0 %}
+            <div class="alert alert-light" role="alert">
+                <h4 class="alert-heading">No blocks with missing sanctioned transactions in the database yet!</h4>
+                <span>There don't seem to be any entries in the database yet.</span>
+                <span>Please check back later.</span>
+            </div>
+        {% else %}
+
+            <h3>
+                Recent Blocks with Missing Sanctioned Transactions ({{ENTRY_COUNT}})
+            </h3>
+            <div>
+                {% for block in blocks %}
+                    <div class="border my-3 px-3 py-2 position-relative grow-on-hover shadow-sm">
+                        {% for tag_id in block.tags %}
+                            {{ block::tag(tag=block_tag_id_to_tag(id=tag_id)) }}
+                        {% endfor %}
+                        <h5 class="text-break fs-5">
+                            Template&nbsp;and&nbsp;Block&nbsp;for&nbsp;<span>{{block.hash}}</span>
+                        </h5>
+                        {{ block::info(block=block, show_previous=false) }}
+                        {{ block::diff(block=block) }}
+                        <hr class="my-2">
+                        {{ block::missing_shared_extra(missing=block.missing_tx, shared=block.shared_tx, extra=block.extra_tx )}}
+                        {{ block::sanctioned(block=block) }}
+
+                        <a href="{{CONFIG.base_url}}/template-and-block/{{block.hash}}" class="stretched-link"></a>
+                    </div>
+                {% endfor %}
+            <div>
+    {% endif %}
+
+    </div>
+</section>
+
+{% endblock content %}

--- a/www/templates/nav.html
+++ b/www/templates/nav.html
@@ -36,7 +36,10 @@
                     <img class="d-inline-block d-lg-none align-middle mx-2" width=32 height=32 src="/static/img/block-conflicting.svg"/>
                     Conflicting Transactions
                 </a>
-
+                <a class="nav-link {%if NAV_PAGE_SANCTIONED%}active{%endif%}" href="{{CONFIG.base_url}}/missing-sanctioned">
+                    <img class="d-inline-block d-lg-none align-middle mx-2" width=32 height=32 src="/static/img/block-sanctioned.svg"/>
+                    Sanctioned Transactions
+                </a>
                 <!-- separator -->
                 <li class="nav-item d-lg-none"><hr class="my-1"></li><li class="nav-item d-none d-lg-block mx-2 border-end"><wbr></li>
                 


### PR DESCRIPTION
Shows sanctioned transactions missing from blocks. Similar to the RSS feed, but a bit more user friendly.

closes https://github.com/0xB10C/miningpool-observer/issues/87