### PR TITLE
change: use random bigint as block id

### DIFF
--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -24,7 +24,7 @@ pub fn run_migrations(
 }
 
 /// Insert a single block
-pub fn insert_block(b: &NewBlock, conn: &mut PgConnection) -> Result<i32, diesel::result::Error> {
+pub fn insert_block(b: &NewBlock, conn: &mut PgConnection) -> Result<i64, diesel::result::Error> {
     use schema::block::dsl::*;
     diesel::insert_into(block)
         .values(b)
@@ -222,7 +222,7 @@ pub fn unknown_pool_blocks(conn: &mut PgConnection) -> Result<Vec<Block>, diesel
 
 pub fn update_pool_name_with_block_id(
     conn: &mut PgConnection,
-    block_id: i32,
+    block_id: i64,
     new_pool_name: &str,
 ) -> Result<(), diesel::result::Error> {
     use schema::block::dsl::*;

--- a/daemon/src/processing.rs
+++ b/daemon/src/processing.rs
@@ -431,7 +431,7 @@ pub fn build_transaction(
 }
 
 pub fn build_transactions_only_in_block(
-    block_id: i32,
+    block_id: i64,
     txids_only_in_block: &HashSet<&Txid>,
     block_txid_to_txinfo_map: &HashMap<Txid, TxInfo>,
     transactions: &mut HashMap<Vec<u8>, shared_model::Transaction>,
@@ -476,7 +476,7 @@ pub fn build_transactions_only_in_block(
 }
 
 pub fn build_sanctioned_transaction_infos(
-    block_id: i32,
+    block_id: i64,
     block_tx_data: &BlockTxData,
     template_txids: &HashSet<Txid>,
     template_txid_to_txinfo_map: &HashMap<Txid, TxInfo>,
@@ -800,7 +800,7 @@ pub fn build_block(
 }
 
 pub fn build_transactions_only_in_template(
-    block_id: i32,
+    block_id: i64,
     txids_only_in_template: &HashSet<&Txid>,
     template_txid_to_txinfo_map: &HashMap<Txid, TxInfo>,
     template_txid_to_mempool_age: &HashMap<Txid, i32>,
@@ -868,7 +868,7 @@ fn add_to_transactions(
 }
 
 pub fn build_conflicting_transactions(
-    block_id: i32,
+    block_id: i64,
     txids_only_in_template: &HashSet<&Txid>,
     template_txid_to_txinfo_map: &HashMap<Txid, TxInfo>,
     txids_only_in_block: &HashSet<&Txid>,
@@ -1131,7 +1131,7 @@ pub fn get_sanctioned_missing_tx_count(
 }
 
 pub fn build_debug_template_selection_infos(
-    block_id: i32,
+    block_id: i64,
     templates: &VecDeque<GetBlockTemplateResult>,
     block_txids: HashSet<Txid>,
     selected_template_time: u64,

--- a/migrations/2025-01-17-100000_make_block_id_a_random_bigserial/down.sql
+++ b/migrations/2025-01-17-100000_make_block_id_a_random_bigserial/down.sql
@@ -1,0 +1,7 @@
+-- Change the type back to SERIAL
+ALTER TABLE block
+    ALTER COLUMN id SET DATA TYPE BIGINT;
+
+-- Reassign ownership of the sequence to the `id` column
+ALTER SEQUENCE block_id_seq OWNED BY block.id;
+

--- a/migrations/2025-01-17-100000_make_block_id_a_random_bigserial/up.sql
+++ b/migrations/2025-01-17-100000_make_block_id_a_random_bigserial/up.sql
@@ -1,0 +1,30 @@
+-- Create a block.id sequence with a random start position.
+-- This allows importing old backups.
+DO $$
+DECLARE
+    random_start BIGINT;
+BEGIN
+    -- Generate a random start value for the sequence
+    random_start := (floor(random() * 9223372036854775807)::BIGINT);
+
+    -- Create the sequence with the random start value
+    EXECUTE format('CREATE SEQUENCE IF NOT EXISTS block_id_seq_random START %s CYCLE', random_start);
+END $$;
+
+ALTER TABLE block
+    ALTER COLUMN id SET DATA TYPE BIGINT, -- Change the column to BIGINT
+    ALTER COLUMN id SET DEFAULT nextval('block_id_seq_random');  -- Use the custom sequence
+
+-- Reassign ownership of the sequence to the `id` column
+ALTER SEQUENCE block_id_seq_random OWNED BY block.id;
+
+ALTER TABLE conflicting_transactions
+    ALTER COLUMN block_id SET DATA TYPE BIGINT;
+ALTER TABLE debug_template_selection
+    ALTER COLUMN block_id SET DATA TYPE BIGINT;
+ALTER TABLE transaction_only_in_block
+    ALTER COLUMN block_id SET DATA TYPE BIGINT;
+ALTER TABLE transaction_only_in_template
+    ALTER COLUMN block_id SET DATA TYPE BIGINT;
+ALTER TABLE sanctioned_transaction_info
+    ALTER COLUMN block_id SET DATA TYPE BIGINT;

--- a/shared/src/model.rs
+++ b/shared/src/model.rs
@@ -18,7 +18,7 @@ use std::hash::{Hash, Hasher};
 #[diesel(primary_key(hash))]
 #[diesel(table_name = block)]
 pub struct Block {
-    pub id: i32,
+    pub id: i64,
     #[serde(with = "serde_hex")]
     pub hash: Vec<u8>,
     #[serde(with = "serde_hex")]
@@ -135,7 +135,7 @@ impl Hash for Transaction {
 #[derive(Insertable, Queryable, Serialize)]
 #[diesel(table_name = transaction_only_in_block)]
 pub struct TransactionOnlyInBlock {
-    pub block_id: i32,
+    pub block_id: i64,
     pub position: i32,
     pub transaction_txid: Vec<u8>,
 }
@@ -143,7 +143,7 @@ pub struct TransactionOnlyInBlock {
 #[derive(Insertable, Queryable, Serialize, Clone)]
 #[diesel(table_name = transaction_only_in_template)]
 pub struct TransactionOnlyInTemplate {
-    pub block_id: i32,
+    pub block_id: i64,
     pub position: i32,
     pub mempool_age_seconds: i32,
     pub transaction_txid: Vec<u8>,
@@ -152,7 +152,7 @@ pub struct TransactionOnlyInTemplate {
 #[derive(Insertable, Queryable, Serialize)]
 #[diesel(table_name = sanctioned_transaction_info)]
 pub struct SanctionedTransactionInfo {
-    pub block_id: i32,
+    pub block_id: i64,
     pub transaction_txid: Vec<u8>,
     pub in_block: bool,
     pub in_template: bool,
@@ -162,7 +162,7 @@ pub struct SanctionedTransactionInfo {
 #[derive(Insertable, Queryable, Serialize, Debug)]
 #[diesel(table_name = conflicting_transactions)]
 pub struct ConflictingTransaction {
-    pub block_id: i32,
+    pub block_id: i64,
     pub template_txids: Vec<Vec<u8>>,
     pub block_txids: Vec<Vec<u8>>,
     pub conflicting_outpoints_txids: Vec<Vec<u8>>,
@@ -193,7 +193,7 @@ pub struct SanctionedUtxoScanInfo {
 #[derive(Insertable, Queryable, Serialize, Debug, Clone)]
 #[diesel(table_name = debug_template_selection)]
 pub struct DebugTemplateSelectionInfo {
-    pub block_id: i32,
+    pub block_id: i64,
     pub template_time: NaiveDateTime,
     pub count_missing: i32,
     pub count_shared: i32,

--- a/shared/src/schema.patch
+++ b/shared/src/schema.patch
@@ -10,7 +10,7 @@ index 8b77f0a..8d5a1a1 100644
 @@ -3,50 +3,50 @@
  diesel::table! {
      block (hash) {
-         id -> Int4,
+         id -> Int8,
          hash -> Bytea,
          prev_hash -> Bytea,
          height -> Int4,
@@ -52,7 +52,7 @@ index 8b77f0a..8d5a1a1 100644
  
  diesel::table! {
      conflicting_transactions (block_id, template_txids, block_txids) {
-         block_id -> Int4,
+         block_id -> Int8,
 -        template_txids -> Array<Nullable<Bytea>>,
 -        block_txids -> Array<Nullable<Bytea>>,
 -        conflicting_outpoints_txids -> Array<Nullable<Bytea>>,
@@ -66,11 +66,11 @@ index 8b77f0a..8d5a1a1 100644
  
  diesel::table! {
      debug_template_selection (block_id, template_time) {
-         block_id -> Int4,
+         block_id -> Int8,
 @@ -66,13 +66,13 @@ diesel::table! {
  diesel::table! {
      sanctioned_transaction_info (block_id, transaction_txid) {
-         block_id -> Int4,
+         block_id -> Int8,
          transaction_txid -> Bytea,
          in_block -> Bool,
          in_template -> Bool,
@@ -103,4 +103,4 @@ index 8b77f0a..8d5a1a1 100644
  
  diesel::table! {
      transaction_only_in_block (block_id, transaction_txid) {
-         block_id -> Int4,
+         block_id -> Int8,

--- a/shared/src/schema.rs
+++ b/shared/src/schema.rs
@@ -2,7 +2,7 @@
 
 diesel::table! {
     block (hash) {
-        id -> Int4,
+        id -> Int8,
         hash -> Bytea,
         prev_hash -> Bytea,
         height -> Int4,
@@ -39,7 +39,7 @@ diesel::table! {
 
 diesel::table! {
     conflicting_transactions (block_id, template_txids, block_txids) {
-        block_id -> Int4,
+        block_id -> Int8,
         template_txids -> Array<Bytea>,
         block_txids -> Array<Bytea>,
         conflicting_outpoints_txids -> Array<Bytea>,
@@ -49,7 +49,7 @@ diesel::table! {
 
 diesel::table! {
     debug_template_selection (block_id, template_time) {
-        block_id -> Int4,
+        block_id -> Int8,
         template_time -> Timestamp,
         count_missing -> Int4,
         count_shared -> Int4,
@@ -73,7 +73,7 @@ diesel::table! {
 
 diesel::table! {
     sanctioned_transaction_info (block_id, transaction_txid) {
-        block_id -> Int4,
+        block_id -> Int8,
         transaction_txid -> Bytea,
         in_block -> Bool,
         in_template -> Bool,
@@ -119,7 +119,7 @@ diesel::table! {
 
 diesel::table! {
     transaction_only_in_block (block_id, transaction_txid) {
-        block_id -> Int4,
+        block_id -> Int8,
         position -> Int4,
         transaction_txid -> Bytea,
     }
@@ -127,7 +127,7 @@ diesel::table! {
 
 diesel::table! {
     transaction_only_in_template (block_id, transaction_txid) {
-        block_id -> Int4,
+        block_id -> Int8,
         position -> Int4,
         mempool_age_seconds -> Int4,
         transaction_txid -> Bytea,


### PR DESCRIPTION
This allows to better import old backups. Previously, the block id's would always start at 1 and would thus overlap.

closes #91 