### PR TITLE
fix: allow dead_code on daemon metrics::PREFIX to fix CI test build

### DIFF
--- a/daemon/src/metrics.rs
+++ b/daemon/src/metrics.rs
@@ -4,6 +4,10 @@ use prometheus::{register_int_counter, register_int_gauge};
 
 // Prometheus Metrics
 
+// Only used inside the lazy_static! block below, which itself is only
+// reachable from `main()`. In `cargo test` builds `main()` is unreachable,
+// so rustc's dead-code analysis flags this as unused without the allow.
+#[allow(dead_code)]
 const PREFIX: &str = "miningpoolobserver_daemon";
 
 lazy_static! {


### PR DESCRIPTION
The strict feature's deny(warnings) turns rustc's dead_code lint into a hard error. In `cargo test` builds the daemon's real `main()` is unreachable (the test harness supplies its own), so PREFIX - only used inside the lazy_static! block that main() drives - gets flagged as unused, breaking CI on the current stable toolchain.